### PR TITLE
Make pkg_info optional

### DIFF
--- a/mindboggle/__init__.py
+++ b/mindboggle/__init__.py
@@ -6,8 +6,12 @@ import os
 #"""
 
 # Set up package information function
-from .pkg_info import get_pkg_info as _get_pkg_info
-get_info = lambda : _get_pkg_info(os.path.dirname(__file__))
+try:
+    from .pkg_info import get_pkg_info as _get_pkg_info
+except:
+    get_info = lambda: ""
+else:
+    get_info = lambda : _get_pkg_info(os.path.dirname(__file__))
 
 # module imports
 #from . import blah as blah


### PR DESCRIPTION
`pkg_info` was removed in 6f914a1328a8b147bae030ee683fca43a2cd941c , but is still referenced `mindboggle/__init__.py`. Rather than remove the code, I made it error to return an empty string.

This is a blocker--I couldn't install `mindboggle` from sources.