### PR TITLE
Handling vtk filenames being blank

### DIFF
--- a/mindboggle/mio/vtks.py
+++ b/mindboggle/mio/vtks.py
@@ -1478,7 +1478,7 @@ def transform_to_volume(vtk_file, volume_file, output_volume=''):
     return output_volume
 
 
-def freesurfer_surface_to_vtk(surface_file, output_vtk):
+def freesurfer_surface_to_vtk(surface_file, output_vtk=''):
     """
     Convert FreeSurfer surface file to VTK format.
 
@@ -1491,7 +1491,9 @@ def freesurfer_surface_to_vtk(surface_file, output_vtk):
     surface_file : string
         name of FreeSurfer surface file
     output_vtk : string
-        name of output VTK file
+        name of output VTK file; if blank, appends
+        ".vtk" to surface_file and saves to the
+        current working directory.
 
     Returns
     -------
@@ -1558,7 +1560,7 @@ def freesurfer_surface_to_vtk(surface_file, output_vtk):
     return output_vtk
 
 
-def freesurfer_curvature_to_vtk(surface_file, vtk_file, output_vtk):
+def freesurfer_curvature_to_vtk(surface_file, vtk_file, output_vtk=''):
     """
     Convert FreeSurfer curvature, thickness, or convexity file to VTK format.
 

--- a/mindboggle/mio/vtks.py
+++ b/mindboggle/mio/vtks.py
@@ -868,6 +868,9 @@ def explode_scalars(input_indices_vtk, input_values_vtk='', output_stem='',
     from mindboggle.mio.vtks import read_scalars, read_vtk, write_vtk
     from mindboggle.guts.mesh import reindex_faces_points, remove_faces
 
+    if not input_values_vtk:
+        input_values_vtk = input_indices_vtk
+
     # Load VTK file:
     faces, lines, indices, points, npoints, scalars, scalar_names, \
         foo1 = read_vtk(input_indices_vtk, True, True)


### PR DESCRIPTION
Three small changes in `mindboggle.mio.vtks`:
* Behavior when `output_vtk` is blank was not documented in the docstring (it was demonstrated in examples, however)
* `output_vtk=''` is a good, meaningful default, the value used in the examples, and the default value for similar arguments... so just make it the default value.
* `input_values_vtk=''` is the default, but if you use that default you get an error. This should set `input_values_vtk = input_indices_vtk`, as implied by downstream code in `explode_scalars`; I simply implemented the two lines to check & set.

Testing:
* I tested these all manually (with defaults, and specifying params).