### PR TITLE
decimate_file only operates in save_vtk=True mode, so don't allow save_vtk=False.

### DIFF
--- a/mindboggle/guts/mesh.py
+++ b/mindboggle/guts/mesh.py
@@ -885,7 +885,7 @@ def decimate(points, faces, reduction=0.75, smooth_steps=25,
 
 
 def decimate_file(input_vtk, reduction=0.5, smooth_steps=100,
-                  save_vtk=False, output_vtk=''):
+                  save_vtk=True, output_vtk=''):
     """
     Decimate vtk triangular mesh file with vtk.vtkDecimatePro.
 
@@ -926,6 +926,9 @@ def decimate_file(input_vtk, reduction=0.5, smooth_steps=100,
     """
     from mindboggle.mio.vtks import read_vtk
     from mindboggle.guts.mesh import decimate
+
+    if not save_vtk:
+        raise NotImplementedError()
 
     # Read VTK surface mesh file:
     faces, u1, u2, points, u4, scalars, u5, u6 = read_vtk(input_vtk)


### PR DESCRIPTION
`decimate_file` only returns a filename. So if you decimate a file and send `save_vtk=False`, you'll just get back an output filename... which wouldn't have your decimated data.